### PR TITLE
Fixes: #18 enif_make_pid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .*~
 *.swp
 *.snippet
+*.dump

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,11 @@ pub struct ErlNifPid {
     pid: ERL_NIF_TERM,
 }
 
+/// See [enif_make_pid](http://erlang.org/doc/man/erl_nif.html#enif_make_pid) in the Erlang docs
+pub fn enif_make_pid(_env: *mut ErlNifEnv, pid: & ErlNifPid) -> ERL_NIF_TERM {
+    pid.pid
+}
+
 /// See [ErlNifSysInfo](http://www.erlang.org/doc/man/erl_nif.html#ErlNifSysInfo) in the Erlang docs.
 #[allow(missing_copy_implementations)]
 #[repr(C)]
@@ -378,4 +383,3 @@ macro_rules! nif_init {
         }
     )
 }
-

--- a/tests/api_functions.rs
+++ b/tests/api_functions.rs
@@ -1,0 +1,56 @@
+use std::process::Command;
+use std::env;
+use std::path::Path;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+#[test]
+fn test_api_functions() {
+	let out_dir = env::var("OUT_DIR").unwrap();
+
+	// Use environment erl, erlc and rustc if available
+	let erl     = env::var("ERL").unwrap_or("erl".to_string());
+	let erlc    = env::var("ERLC").unwrap_or("erlc".to_string());
+	let rustc   = env::var("RUSTC").unwrap_or("rustc".to_string());
+
+	// Compile rust nif library
+    let path = Path::new(&out_dir).join("../../../deps");
+    // TODO: .so extension is platform-dependent - fix it
+    let out = Path::new(&out_dir).join("api_functions_nif.so");
+    match Command::new(rustc).arg("-L").arg(&path).arg("--crate-type").arg("dylib")
+                             .arg("-o").arg(&out).arg("tests/api_functions_nif.rs")
+    	.status()
+    	.map_err(|_|"Can't find rust compiler (rustc or value of environment RUSTC)")
+    	.unwrap().success() {
+    		false => panic!("Can't compile api_functions_nif.rs"),
+    		_     => ()
+    	};
+
+	// Compile erlang nif library
+    match Command::new(erlc).arg("-o").arg(&out_dir).arg("tests/api_functions_nif.erl")
+    	.status()
+    	.map_err(|_|"Can't find erlang compiler (erlc or value of environment ERLC)")
+    	.unwrap().success() {
+    		false => panic!("Can't compile api_functions_nif.erl"),
+    		_ => ()
+    	};
+
+    // Execute erlang tests
+    let stdout:Vec<u8> = Command::new(erl).arg("-pz").arg(&out_dir).arg("-noshell")
+                                          .arg("-s").arg("api_functions_nif")
+                                          .arg("-s").arg("init").arg("stop").output()
+    	.map_err(|_|"Can't run api_functions_nif.erl")
+    	.unwrap().stdout;
+ 	let output:&str = std::str::from_utf8(&stdout).unwrap();
+
+    //println!("\nerlang output:\n {}\n", output);
+
+ 	// Parse erl program output into hashmap of (&str, &str)
+	let sizemap = HashMap::<&str, &str>::from_iter(
+		output.lines().map(|ln|ln.split(" "))
+		.map(|mut it| (it.next().unwrap(), it.next().unwrap())));
+
+	assert_eq!(sizemap.get("nif_loaded").unwrap(), &"true");
+	assert_eq!(sizemap.get("enif_make_int").unwrap(), &"true");
+	assert_eq!(sizemap.get("enif_make_pid").unwrap(), &"true");
+}

--- a/tests/api_functions_nif.erl
+++ b/tests/api_functions_nif.erl
@@ -1,0 +1,16 @@
+-module(api_functions_nif).
+-export([start/0, test_enif_make_int/0, test_enif_make_pid/0]).
+
+load_nif() ->
+    Lib = filename:join(os:getenv("OUT_DIR"), "api_functions_nif"),
+    erlang:load_nif(Lib, []).
+
+test_enif_make_int() ->
+    "NIF library not loaded".
+test_enif_make_pid() ->
+    "NIF library not loaded".
+
+start() ->
+    io:fwrite("nif_loaded ~w~n", [load_nif() == ok]),
+    io:fwrite("enif_make_int ~w~n", [test_enif_make_int() == -10]),
+    io:fwrite("enif_make_pid ~w~n", [is_pid(test_enif_make_pid())]).

--- a/tests/api_functions_nif.rs
+++ b/tests/api_functions_nif.rs
@@ -1,0 +1,20 @@
+#[macro_use]
+extern crate erlang_nif_sys;
+use erlang_nif_sys::*;
+
+extern "C" fn test_enif_make_int(env: *mut ErlNifEnv, _: c_int, _: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
+    unsafe { enif_make_int(env, -10) }
+}
+
+extern "C" fn test_enif_make_pid(env: *mut ErlNifEnv, _: c_int, _: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
+    let mut pid: ErlNifPid = unsafe { std::mem::uninitialized() };
+    unsafe { enif_self(env, &mut pid) };
+    enif_make_pid(env, &pid)
+}
+
+nif_init!(
+    b"api_functions_nif\0",
+    None, None, None, None,
+    nif!(b"test_enif_make_int\0", 0, test_enif_make_int),
+    nif!(b"test_enif_make_pid\0", 0, test_enif_make_pid)
+);


### PR DESCRIPTION
some remarks:

* `enif_make_pid` added to `src/lib.rs`
* some testing boilerplate added to `tests`. The code compiles `api_functions_nif.rs` and `api_functions_nif.erl` and then runs `api_functions_nif.erl` and captures and analyzes results as it was done in `struct_size.rs`. Two minimal tests added for `enif_make_int` and `enif_make_pid`
* *.dump added to `.gitignore` becouse such files generated while erl VM crashes in tests