### PR TITLE
Unsafe fn 2

### DIFF
--- a/gen_api.erl
+++ b/gen_api.erl
@@ -110,7 +110,7 @@ api_list(Opts) -> [
     %%      {"*mut c_void", "enif_tsd_get", "key: ErlNifTSDKey"},
     %%      {"*mut ErlNifThreadOpts", "enif_thread_opts_create", "name: *mut c_uchar"},
     %%      {"", "enif_thread_opts_destroy", "opts: *mut ErlNifThreadOpts"},
-    %%      {"c_int", "enif_thread_create", "name: *mut c_uchar, tid: *mut ErlNifTid, func: Option<extern \"C\" fn (arg1: *mut c_void) -> *mut c_void>, args: *mut c_void, opts: *mut ErlNifThreadOpts"},
+    %%      {"c_int", "enif_thread_create", "name: *mut c_uchar, tid: *mut ErlNifTid, func: Option<unsafe extern \"C\" fn (arg1: *mut c_void) -> *mut c_void>, args: *mut c_void, opts: *mut ErlNifThreadOpts"},
     %%      {"ErlNifTid", "enif_thread_self", ""},
     %%      {"c_int", "enif_equal_tids", "tid1: ErlNifTid, tid2: ErlNifTid"},
     %%      {"", "enif_thread_exit", "resp: *mut c_void"},
@@ -165,7 +165,7 @@ api_list(Opts) -> [
     {"ERL_NIF_TERM", "enif_make_tuple_from_array", "arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint"},
     {"ERL_NIF_TERM", "enif_make_list_from_array", "arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint"},
     {"c_int", "enif_is_empty_list", "arg1: *mut ErlNifEnv, term: ERL_NIF_TERM"},
-    {"*const ErlNifResourceType", "enif_open_resource_type", "arg1: *mut ErlNifEnv, module_str: *const c_uchar, name_str: *const c_uchar, dtor: Option<extern \"C\" fn (arg1: *mut ErlNifEnv, arg2: *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags"},
+    {"*const ErlNifResourceType", "enif_open_resource_type", "arg1: *mut ErlNifEnv, module_str: *const c_uchar, name_str: *const c_uchar, dtor: Option<unsafe extern \"C\" fn (arg1: *mut ErlNifEnv, arg2: *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags"},
     {"*mut c_void", "enif_alloc_resource", "_type: *const ErlNifResourceType, size: size_t"},
     {"", "enif_release_resource", "obj: *const c_void"},
     {"ERL_NIF_TERM", "enif_make_resource", "arg1: *mut ErlNifEnv, obj: *const c_void"},
@@ -204,8 +204,8 @@ api_list(Opts) -> [
     {"c_int", "enif_is_exception", "arg1: *mut ErlNifEnv, term: ERL_NIF_TERM"},
     {"c_int", "enif_make_reverse_list", "arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM"},
     {"c_int", "enif_is_number", "arg1: *mut ErlNifEnv, term: ERL_NIF_TERM"},
-    {"*mut c_void", "enif_dlopen", "lib: *const c_uchar, err_handler: Option<extern \"C\" fn (arg1: *mut c_void, arg2: *const c_uchar)>, err_arg: *mut c_void"},
-    {"*mut c_void", "enif_dlsym", "handle: *mut c_void, symbol: *const c_uchar, err_handler: Option<extern \"C\" fn (arg1: *mut c_void, arg2: *const c_uchar)>, err_arg: *mut c_void"},
+    {"*mut c_void", "enif_dlopen", "lib: *const c_uchar, err_handler: Option<unsafe extern \"C\" fn (arg1: *mut c_void, arg2: *const c_uchar)>, err_arg: *mut c_void"},
+    {"*mut c_void", "enif_dlsym", "handle: *mut c_void, symbol: *const c_uchar, err_handler: Option<unsafe extern \"C\" fn (arg1: *mut c_void, arg2: *const c_uchar)>, err_arg: *mut c_void"},
     {"c_int", "enif_consume_timeslice", "arg1: *mut ErlNifEnv, percent: c_int"},
     {"c_int", "enif_is_map", "env: *mut ErlNifEnv, term: ERL_NIF_TERM"},
     {"c_int", "enif_get_map_size", "env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t"},
@@ -221,7 +221,7 @@ api_list(Opts) -> [
     {"c_int", "enif_map_iterator_next", "env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator"},
     {"c_int", "enif_map_iterator_prev", "env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator"},
     {"c_int", "enif_map_iterator_get_pair", "env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM"},
-    {"ERL_NIF_TERM", "enif_schedule_nif", "env: *mut ErlNifEnv, fun_name: *const c_uchar, flags:c_int, dtor: Option<extern \"C\" fn(env: *mut ErlNifEnv, argc:c_int, argv:*const ERL_NIF_TERM)>, argc:c_int, argv:*const ERL_NIF_TERM"}
+    {"ERL_NIF_TERM", "enif_schedule_nif", "env: *mut ErlNifEnv, fun_name: *const c_uchar, flags:c_int, dtor: Option<unsafe extern \"C\" fn(env: *mut ErlNifEnv, argc:c_int, argv:*const ERL_NIF_TERM)>, argc:c_int, argv:*const ERL_NIF_TERM"}
     ] ++
 
 

--- a/tests/testapp/crates/mynifmod/src/lib.rs
+++ b/tests/testapp/crates/mynifmod/src/lib.rs
@@ -3,13 +3,28 @@
 extern crate erlang_nif_sys;
 use erlang_nif_sys::*;
 
-use std::mem;
+use std::{mem, ptr};
+
+static mut RUSTMAP_TYPE: *const ErlNifResourceType = 0 as *const ErlNifResourceType;
 
 nif_init!("mynifmod", [
 	("times2", 1, slice_args!(times2)),
 	("test_enif_make_pid", 0, test_enif_make_pid),
-	]);
+	("rustmap", 0, rustmap),
+	],
+	{load: mynifmod_load});
 
+unsafe fn mynifmod_load(env: *mut ErlNifEnv, _priv_data: *mut *mut c_void, _load_info: ERL_NIF_TERM) -> c_int {
+	let mut tried: ErlNifResourceFlags = mem::uninitialized();
+	RUSTMAP_TYPE = enif_open_resource_type(
+		env,
+		ptr::null(),
+		b"rustmap\0".as_ptr(),
+		Some(rustmap_destructor),
+		ErlNifResourceFlags::ERL_NIF_RT_CREATE,
+		&mut tried);
+	RUSTMAP_TYPE.is_null() as c_int
+}
 
 fn times2(env: *mut ErlNifEnv, args: &[ERL_NIF_TERM]) -> ERL_NIF_TERM {
 	unsafe {
@@ -27,4 +42,25 @@ fn test_enif_make_pid(env: *mut ErlNifEnv, _: c_int, _: *const ERL_NIF_TERM) -> 
     let mut pid: ErlNifPid = unsafe { mem::uninitialized() };
     unsafe { enif_self(env, &mut pid) };
     unsafe { enif_make_pid(env, &pid) }
+}
+
+use std::collections::HashMap;
+type RustMap = HashMap<String, String>;
+
+unsafe extern "C" fn rustmap_destructor(_env: *mut ErlNifEnv, handle: *mut c_void) {
+    ptr::read(handle as *mut RustMap);
+}
+
+unsafe fn rustmap(env: *mut ErlNifEnv, _: c_int, _: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
+    // Create a value with nontrivial destructor cleanup.
+    let mut map = RustMap::new();
+    map.insert("Rust".to_string(), "Erlang".to_string());
+    map.insert("Erlang".to_string(), "Rust".to_string());
+
+    let mem = enif_alloc_resource(RUSTMAP_TYPE, mem::size_of::<RustMap>());
+    assert_eq!(mem as usize % mem::align_of::<RustMap>(), 0);
+    ptr::write(mem as *mut RustMap, map);
+    let term = enif_make_resource(env, mem);
+    enif_release_resource(mem);
+    term
 }

--- a/tests/testapp/mynifmod.erl
+++ b/tests/testapp/mynifmod.erl
@@ -19,16 +19,25 @@ find_library(CrateName, LibName) ->
 		_ -> {error, multiple_matches}
 	end.
 
+exercise_dtor(0) ->
+	garbage_collect(), %% don't crash
+	[];
+exercise_dtor(N) ->
+	rustmap(),  %% create and discard a resource
+	exercise_dtor(N - 1).
 
 simple_test_() -> [
 		?_assertEqual(6, times2(3)),
-		?_assertEqual(self(), test_enif_make_pid())
+		?_assertEqual(self(), test_enif_make_pid()),
+		?_assertEqual(<<"">>, rustmap()),
+		exercise_dtor(10)
 	].
 
 
 
 times2(_X)           -> exit(nif_library_not_loaded).
 test_enif_make_pid() -> exit(nif_library_not_loaded).
+rustmap()            -> exit(nif_library_not_loaded).
 
 
 


### PR DESCRIPTION
There don't appear to be any tests for these, so I wrote one; but something bugs me about the behavior of the test I wrote. If you put a `println!` in `rustmap` and one in `rustmap_destructor`, you can see that they're each called 21 times. I think they should only be called 11 times. I couldn't figure it out.